### PR TITLE
Add instant-wakeup config flag and fix /sleepanimation reload

### DIFF
--- a/src/main/java/io/github/derec4/sleepAnimation/ConfigManager.java
+++ b/src/main/java/io/github/derec4/sleepAnimation/ConfigManager.java
@@ -5,16 +5,21 @@ import org.bukkit.configuration.file.FileConfiguration;
 public class ConfigManager {
 
     private static int skipSpeed;
+    private static boolean instantWakeup;
 
     public static void loadConfig(SleepAnimation plugin) {
         plugin.saveDefaultConfig();
         FileConfiguration config = plugin.getConfig();
 
         skipSpeed = config.getInt("skip-speed", 50);
+        instantWakeup = config.getBoolean("instant-wakeup", false);
     }
 
     public static int getSkipSpeed() {
         return skipSpeed;
     }
-}
 
+    public static boolean isInstantWakeup() {
+        return instantWakeup; 
+    }
+}

--- a/src/main/java/io/github/derec4/sleepAnimation/SleepAnimationCommand.java
+++ b/src/main/java/io/github/derec4/sleepAnimation/SleepAnimationCommand.java
@@ -34,6 +34,7 @@ public class SleepAnimationCommand implements CommandExecutor {
             }
 
             // reload config and restart the TimeSkipper with new settings
+            plugin.reloadConfig();
             ConfigManager.loadConfig(plugin);
             TimeSkipper old = plugin.getTimeSkipper();
             if (old != null) {

--- a/src/main/java/io/github/derec4/sleepAnimation/SleepListener.java
+++ b/src/main/java/io/github/derec4/sleepAnimation/SleepListener.java
@@ -4,6 +4,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.TimeSkipEvent;
+import org.bukkit.entity.Player;
 
 public class SleepListener implements Listener {
 
@@ -19,6 +20,14 @@ public class SleepListener implements Listener {
             event.setCancelled(true);
 //            Bukkit.getLogger().info("Playing night skip animation");
             plugin.getTimeSkipper().startAnimation(event.getWorld());
+
+            if (ConfigManager.isInstantWakeup()) {
+                for (Player player : event.getWorld().getPlayers()) {
+                    if (player.isSleeping()) {
+                        player.wakeup(false);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,3 +3,7 @@
 # Default: 50
 skip-speed: 50
 
+# Whether players should be instantly forced out of bed when the sleep animation begins
+# If false, players remain in bed for the whole animation duration
+# Default: false
+instant-wakeup: false


### PR DESCRIPTION
I really like the plugin, but my players found it annoying that they had to stay in bed during the animation for longer than the vanilla duration (even if they could manually leave).

I thought it would be cool to add an option to solve this, so I've added an `instant-wakeup` flag in the config to automatically wake players up instead of waiting.

Also, I noticed the `/sleepanimation reload` command wasn't correctly reloading the updated config from disk, so I've included a fix for that too.